### PR TITLE
chore: KISS/DRY cleanup — lint debt, CI hardening, docs restructure

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,15 +20,15 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v5
+      uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
 
     - name: Set up Go
-      uses: actions/setup-go@v6
+      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
       with:
         go-version: '1.24.7'
 
     - name: Cache Go modules
-      uses: actions/cache@v4
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
       with:
         path: |
           ~/.cache/go-build
@@ -73,7 +73,7 @@ jobs:
         sha256sum "${BINARY_NAME}_${{ matrix.goos }}_${{ matrix.goarch }}$([ "${{ matrix.goos }}" = "windows" ] && echo ".exe" || echo "")" > "${BINARY_NAME}_${{ matrix.goos }}_${{ matrix.goarch }}.sha256"
 
     - name: Upload build artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
       with:
         name: binaries-${{ matrix.goos }}-${{ matrix.goarch }}
         path: dist/*
@@ -86,13 +86,13 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v5
+      uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
 
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
+      uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
 
     - name: Download Linux AMD64 binary
-      uses: actions/download-artifact@v5
+      uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0
       with:
         name: binaries-linux-amd64
         path: dist/
@@ -118,7 +118,7 @@ jobs:
         docker save xp-provider-gen:${VERSION} | gzip > xp-provider-gen-${VERSION}.tar.gz
 
     - name: Upload Docker image artifact
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
       with:
         name: docker-image
         path: xp-provider-gen-*.tar.gz

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,27 +18,27 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v5
+      uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
 
     - name: Set up Go
-      uses: actions/setup-go@v6
+      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
       with:
         go-version: '1.24.7'
 
     - name: Run Gosec Security Scanner
-      uses: securego/gosec@v2.22.10
+      uses: securego/gosec@6be2b51fd78feca86af91f5186b7964d76cb1256 # v2.22.10
       with:
         args: '-fmt sarif -out gosec-results.sarif -severity medium -confidence medium ./...'
       continue-on-error: true
 
     - name: Upload Gosec scan results to GitHub Security tab
-      uses: github/codeql-action/upload-sarif@v3
+      uses: github/codeql-action/upload-sarif@dd903d2e4f5405488e5ef1422510ee31c8b32357 # v3.36.2
       if: always() && hashFiles('gosec-results.sarif') != ''
       with:
         sarif_file: gosec-results.sarif
 
     - name: Run Trivy vulnerability scanner
-      uses: aquasecurity/trivy-action@0.33.1
+      uses: aquasecurity/trivy-action@b6643a29fecd7f34b3597bc6acb0a98b03d33ff8 # v0.33.1
       continue-on-error: true
       with:
         scan-type: 'fs'
@@ -47,7 +47,7 @@ jobs:
         output: 'trivy-results.sarif'
 
     - name: Upload Trivy scan results to GitHub Security tab
-      uses: github/codeql-action/upload-sarif@v3
+      uses: github/codeql-action/upload-sarif@dd903d2e4f5405488e5ef1422510ee31c8b32357 # v3.36.2
       if: always() && hashFiles('trivy-results.sarif') != ''
       with:
         sarif_file: 'trivy-results.sarif'

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,15 +13,15 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v5
+      uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
 
     - name: Set up Go
-      uses: actions/setup-go@v6
+      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
       with:
         go-version: '1.24.7'
 
     - name: Cache Go modules
-      uses: actions/cache@v4
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
       with:
         path: |
           ~/.cache/go-build
@@ -34,7 +34,7 @@ jobs:
       run: go mod download
 
     - name: Run golangci-lint
-      uses: golangci/golangci-lint-action@v8
+      uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9 # v8.0.0
       with:
         version: latest
         args: --timeout=5m

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,17 +16,17 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v5
+      uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
       with:
         fetch-depth: 0
 
     - name: Set up Go
-      uses: actions/setup-go@v6
+      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
       with:
         go-version: '1.24.7'
 
     - name: Cache Go modules
-      uses: actions/cache@v4
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
       with:
         path: |
           ~/.cache/go-build
@@ -106,7 +106,7 @@ jobs:
         fi
 
     - name: Create GitHub Release
-      uses: softprops/action-gh-release@v2
+      uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2.6.2
       with:
         body_path: CHANGELOG.md
         files: |
@@ -125,13 +125,13 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v5
+      uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
 
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
+      uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
 
     - name: Log in to GitHub Container Registry
-      uses: docker/login-action@v3
+      uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
       with:
         registry: ghcr.io
         username: ${{ github.actor }}
@@ -139,7 +139,7 @@ jobs:
 
     - name: Extract metadata
       id: meta
-      uses: docker/metadata-action@v5
+      uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v5.10.0
       with:
         images: ghcr.io/${{ github.repository }}
         tags: |
@@ -149,7 +149,7 @@ jobs:
           type=semver,pattern={{major}}
 
     - name: Build and push Docker image
-      uses: docker/build-push-action@v6
+      uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
       with:
         context: .
         platforms: linux/amd64,linux/arm64

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
       source: ${{ steps.changes.outputs.source }}
     steps:
     - name: Checkout code
-      uses: actions/checkout@v5
+      uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
       with:
         fetch-depth: 0
 
@@ -49,15 +49,15 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v5
+      uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
 
     - name: Set up Go
-      uses: actions/setup-go@v6
+      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
       with:
         go-version: ${{ matrix.go-version }}
 
     - name: Cache Go modules
-      uses: actions/cache@v4
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
       with:
         path: |
           ~/.cache/go-build
@@ -75,13 +75,13 @@ jobs:
         go tool cover -html=coverage.out -o coverage.html
 
     - name: Upload coverage reports
-      uses: codecov/codecov-action@v5
+      uses: codecov/codecov-action@0fb7174895f61a3b6b78fc075e0cd60383518dac # v5.5.5
       with:
         file: ./coverage.out
         fail_ci_if_error: false
 
     - name: Upload coverage artifact
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
       with:
         name: coverage-report-go${{ matrix.go-version }}
         path: coverage.html
@@ -94,15 +94,15 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v5
+      uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
 
     - name: Set up Go
-      uses: actions/setup-go@v6
+      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
       with:
         go-version: '1.24.7'
 
     - name: Cache Go modules
-      uses: actions/cache@v4
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
       with:
         path: |
           ~/.cache/go-build

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -24,7 +24,7 @@ linters:
     - gocyclo
     - godot
     - gomoddirectives
-    - gomodguard
+    - gomodguard_v2
     - goprintffuncname
     - gosec
     - govet

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,61 @@
+# CLAUDE.md
+
+Guidance for working in this repository. Keep this file short — depth lives in [`docs/`](docs/).
+
+## What this is
+
+`xp-provider-gen` is a Go CLI that scaffolds [Crossplane](https://crossplane.io) providers
+using Kubebuilder v4 and crossplane-runtime v2. From `init` + `create api` commands it
+generates a complete, buildable provider project.
+
+## Core principles
+
+These two override cleverness. If a change makes the code harder to understand, stop and reconsider.
+
+- **KISS — Keep It Simple.** Prefer the smallest, most obvious solution. No speculative
+  abstraction, no configuration knobs nobody asked for, no dead code kept "for later."
+  A new reader should understand a file without a guided tour.
+- **DRY — Don't Repeat Yourself.** A fact, string, or rule lives in exactly one place.
+  Repeated string literals become named constants; repeated logic becomes a shared
+  function. The linter enforces part of this (`goconst`, `dupl`).
+
+Everything below serves these two.
+
+## Working agreements
+
+- **Verify before claiming done.** Run `make reviewable` (fmt, vet, lint, gosec, tidy,
+  test). CI runs the same checks — green locally means green in CI.
+- **Match the surrounding code.** Idiomatic Go: small files, explicit error wrapping
+  (`fmt.Errorf("...: %w", err)`), table-driven tests.
+- **Templates are data.** Provider scaffolding lives in `pkg/templates/files/**/*.tmpl`
+  and is auto-discovered (see [docs/architecture.md](docs/architecture.md)). Add a template
+  file — do not wire it in by hand.
+- **Conventional commits**, small and focused: `feat:`, `fix:`, `refactor:`, `chore:`,
+  `ci:`, `docs:`, `test:`.
+- **Pin GitHub Actions to commit SHAs**, never floating tags (supply-chain safety).
+  Renovate keeps the digests updated.
+
+## Essential commands
+
+| Command | Purpose |
+|---------|---------|
+| `make build` | Build the `bin/xp-provider-gen` binary |
+| `make test` | Unit tests with the race detector |
+| `make lint` | golangci-lint (config in `.golangci.yml`) |
+| `make e2e-test` | Full scaffold → build workflow against a temp project |
+| `make reviewable` | Everything CI runs; do this before pushing |
+| `make help` | List all targets |
+
+## Where things are
+
+- `cmd/xp-provider-gen/` — CLI entry point (Kubebuilder CLI wiring)
+- `pkg/plugins/crossplane/v2/` — the plugin: commands, template engine, automation, validation
+- `pkg/templates/files/` — embedded `.tmpl` scaffolding for generated providers
+- `scripts/e2e-test.sh` — local end-to-end test
+
+## Deeper docs
+
+- [docs/architecture.md](docs/architecture.md) — how the generator is structured
+- [docs/development.md](docs/development.md) — environment, tooling, and workflow
+- [docs/testing.md](docs/testing.md) — unit and end-to-end testing
+- [.github/WORKFLOWS.md](.github/WORKFLOWS.md) — CI/CD pipelines

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ COVERAGE_DIR=coverage
 # Binary names
 BINARY=xp-provider-gen
 
-.PHONY: help build clean test coverage fmt vet lint lint-fix lint-install gosec mod-tidy mod-verify check reviewable integration-test ci-test ci-lint ci-gosec e2e-test docs
+.PHONY: help build clean test coverage fmt vet lint lint-fix lint-install gosec mod-tidy mod-verify check reviewable ci-test ci-lint ci-gosec e2e-test
 
 help: ## Show this help message
 	@echo "Available targets:"
@@ -37,7 +37,7 @@ help: ## Show this help message
 	@grep -E '^(build|clean):.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "  %-15s %s\n", $$1, $$2}'
 	@echo ""
 	@echo "Testing:"
-	@grep -E '^(test|coverage|e2e-test|integration-test):.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "  %-15s %s\n", $$1, $$2}'
+	@grep -E '^(test|coverage|e2e-test):.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "  %-15s %s\n", $$1, $$2}'
 	@echo ""
 	@echo "Code Quality:"
 	@grep -E '^(fmt|vet|lint|lint-fix|gosec|check|reviewable):.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "  %-15s %s\n", $$1, $$2}'
@@ -49,7 +49,7 @@ help: ## Show this help message
 	@grep -E '^(ci-test|ci-lint|ci-gosec):.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "  %-15s %s\n", $$1, $$2}'
 	@echo ""
 	@echo "Other:"
-	@grep -E '^(help|docs):.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "  %-15s %s\n", $$1, $$2}'
+	@grep -E '^(help):.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "  %-15s %s\n", $$1, $$2}'
 
 build: ## Build the standalone Crossplane provider generator
 	@echo "Building Crossplane provider generator..."
@@ -92,7 +92,6 @@ lint: lint-install ## Run golangci-lint with configuration
 
 gosec: ## Run gosec security scanner
 	@echo "Running gosec security scanner..."
-	@echo "Running gosec security scanner..."
 	gosec -fmt=text -out=gosec-report.txt -stdout -verbose=text -severity=medium -confidence=medium ./...
 
 mod-tidy: ## Run go mod tidy
@@ -123,17 +122,4 @@ ci-gosec: ## Run gosec for CI with JSON output
 lint-fix: lint-install ## Run golangci-lint with auto-fixing
 	@echo "Running golangci-lint with auto-fix..."
 	golangci-lint run --config .golangci.yml --fix
-
-# Documentation
-
-docs: ## Generate documentation (placeholder)
-	@echo "Documentation generation not yet implemented"
-	@echo "See README.md and IMPLEMENTATION_PLAN.md for current documentation"
-
-# Integration testing
-
-integration-test: build ## Run comprehensive integration tests
-	@echo "Running integration tests..."
-	./scripts/integration-test.sh
-	@echo "Integration tests completed!"
 

--- a/README.md
+++ b/README.md
@@ -60,44 +60,23 @@ xp-provider-gen create api --group=GROUP --version=VERSION --kind=KIND [--force]
 
 ## Working on This Project
 
-### Requirements
-- Go 1.24.7+
-- Git
-- golangci-lint (for linting)
-- gosec (for security scanning)
-
-### Install Development Dependencies
-
-**gosec (macOS):**
-```bash
-brew install gosec
-```
-
-**gosec (direct):**
-```bash
-go install github.com/securego/gosec/v2/cmd/gosec@v2.22.9
-```
-
-### Development Commands
+Quick start for contributors:
 
 ```bash
-make help        # Show all available commands
 make build       # Build the binary
-make test        # Run unit tests
-make lint        # Run linter
-make check       # Run all quality checks
-make reviewable  # Make code ready for review
+make reviewable  # fmt + vet + lint + gosec + test (run before pushing)
+make e2e-test    # Full scaffold → build workflow
+make help        # List all targets
 ```
 
-### End-to-End Testing
+Requires Go 1.26+, Git, and gosec (`brew install gosec`). golangci-lint installs on demand.
 
-```bash
-make e2e-test  # Validates complete workflow: init → create APIs → build → verify
-```
+For the full developer guide see:
 
-### Working with Templates
-
-Templates are in `pkg/templates/files/` with auto-discovery support. After changes: `make build && make e2e-test`
+- [CLAUDE.md](CLAUDE.md) — project principles and conventions
+- [docs/architecture.md](docs/architecture.md) — how the generator works
+- [docs/development.md](docs/development.md) — environment, tooling, and workflow
+- [docs/testing.md](docs/testing.md) — unit and end-to-end testing
 
 ### Generated Project Structure
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,148 @@
+# Architecture
+
+`xp-provider-gen` is a CLI built on the **Kubebuilder v4 plugin system**. It scaffolds a
+complete Crossplane provider project from embedded templates and then runs a post-scaffold
+automation pipeline (git init, module tidy, code generation).
+
+The code is organized into clearly separated layers:
+
+```
+cmd/xp-provider-gen/            CLI entry point (Kubebuilder CLI wiring)
+pkg/plugins/crossplane/v2/
+├── plugin.go, init.go,         Plugin layer — subcommands (init, create api)
+│   createapi.go, config.go
+├── core/                       Reusable building blocks (git, exec, config, parsing)
+├── templates/engine/           Template discovery, building, and registration updaters
+├── automation/                 Post-scaffold pipeline (steps + git operations)
+└── validation/                 Input validation (domain, repo, group/version/kind)
+pkg/templates/                  Embedded template filesystem (go:embed) + loader
+```
+
+## 1. Entry point & command flow
+
+`cmd/xp-provider-gen/main.go` constructs a Kubebuilder CLI and registers the Crossplane
+plugin:
+
+```go
+cli.New(
+    cli.WithCommandName("crossplane-provider-gen"),
+    cli.WithPlugins(&crossplanev2.Plugin{}),
+    cli.WithDefaultPlugins(cfgv3.Version, &crossplanev2.Plugin{}),
+)
+```
+
+Kubebuilder routes `init` and `create api` to the plugin's subcommands, each driven through
+the standard lifecycle: `BindFlags` → `InjectConfig` → `PreScaffold` → `Scaffold` → `PostScaffold`.
+
+## 2. Plugin layer (`pkg/plugins/crossplane/v2/`)
+
+- **`plugin.go`** — `Plugin` implements Kubebuilder's `plugin.Full`, advertises config v3 /
+  plugin v2, and returns the init and create-api subcommands.
+- **`init.go`** — binds `--domain`, `--repo`, `--git-name`, `--git-email`; validates inputs;
+  resolves git author (CLI flags > system git config > defaults); scaffolds init + static
+  templates; saves the PROJECT file; runs the init automation pipeline.
+- **`createapi.go`** — injects the Kubebuilder resource model with Crossplane defaults;
+  validates the resource; pulls API templates from the factory; chains in the registration
+  updaters; persists the resource to PROJECT; runs the API-commit pipeline.
+- **`config.go`** — alias to `core.PluginConfig`; `NewPluginConfig()` seeds defaults.
+- **`errors_compat.go`** — thin shim delegating to the `validation` package.
+
+## 3. Core layer (`pkg/plugins/crossplane/v2/core/`)
+
+Reusable, side-effecting building blocks with no template knowledge:
+
+- **`command_runner.go`** — `CommandRunner` wraps `exec.CommandContext` with a working dir.
+- **`git_runner.go`** — `GitCommandRunner`: `Init`, `Add`, `Commit`/`CommitWithAuthor`,
+  `GetUserName/Email`, `AddSubmodule`.
+- **`config.go`** — `PluginConfig` (domain, repo prefix, git author, `force`/`generateClient`
+  flags); `GenerateDefaultRepo()` names a provider `provider-{dirname}`.
+- **`file_parser.go`** — configurable, regex/section-marker Go-source parser with a fluent
+  `FileParserBuilder`; used by the updaters to read existing imports/registrations.
+- **`project.go`** — `ProjectFile` wraps Kubebuilder config; `Save()` and `AddResource()`.
+- **`provider.go`** — `ExtractProviderName` / `ExtractProjectName` helpers.
+- **`template_path_processor.go`** — maps a template path to an output path: strips `files/`
+  and `.tmpl`, applies `{GROUP}`/`{VERSION}`/`{KIND}`/`{IMAGENAME}` replacements, special-cases
+  the `project/` prefix for root-level files.
+
+## 4. Template engine (`pkg/plugins/crossplane/v2/templates/engine/`)
+
+The engine turns embedded `.tmpl` files into Kubebuilder template products. Its defining
+trait is **auto-discovery**: templates are found by walking the embedded filesystem at
+factory init, not registered by hand.
+
+- **Discovery** — `autodiscovery.go` walks the FS and classifies each template into
+  `InitCategory`, `APICategory`, or `StaticCategory` by path pattern. `loader.go`
+  (`TemplateLoader`) reads template bodies from the embedded FS.
+- **Factory** — `factory.go` (`CrossplaneTemplateFactory`) registers discovered templates
+  into `initRegistry` / `apiRegistry` / `staticRegistry` and exposes `Create*Template` and
+  `Get*Templates`.
+- **Strategy pattern** — `builders.go` defines `BuildStrategy` (`GetCategory`,
+  `ValidateOptions`, `GenerateReplacements`) with `Init` / `API` / `Static` implementations;
+  `BaseTemplateBuilder` delegates to the chosen strategy. `placeholderImageName` and the
+  `GROUP`/`VERSION`/`KIND` keys are the replacement variables.
+- **Products** — `product_base.go` (`BaseTemplateProduct`) embeds Kubebuilder machinery
+  mixins (Template/Domain/Repository/Boilerplate/Resource); `product_generic.go`
+  (`GenericTemplateProduct`) loads any discovered template's body in `SetTemplateDefaults()`.
+- **Updaters** — `api_registration_updater.go` rewrites `apis/register.go`, and
+  `template_updater.go` rewrites `internal/controller/register.go`, merging new imports and
+  registrations with existing ones (de-duplicated) so adding an API wires itself in.
+
+## 5. Automation pipeline (`pkg/plugins/crossplane/v2/automation/`)
+
+A simple chain-of-steps run after scaffolding:
+
+- **`steps.go`** — `Step` interface (`Name`, `Execute`, `IsRequired`); concrete steps:
+  `GitInitStep`, `GitCommitStep`, `GitSubmoduleStep`, `MakeStep(target)`, `GoModTidyStep`.
+- **`pipeline.go`** — `NewInitPipeline()` runs git init → commit → submodule → `make
+  submodules` → `go mod tidy` → `make generate` → `make reviewable`; `NewAPICommitPipeline()`
+  runs git commit → `make generate`. `Run()` is sequential, fails fast on required steps and
+  warns on optional ones.
+- **`git.go`** — `GitOperations` over `GitCommandRunner`: idempotent `Init`, `CreateCommit`
+  (system git config or explicit author), idempotent `AddSubmodule`.
+
+## 6. Validation (`pkg/plugins/crossplane/v2/validation/`)
+
+`validator.go` enforces Kubebuilder/Kubernetes conventions: domain (DNS name), repository
+(Go module path, warns if not `provider-*`), group (DNS-1123, ≤63), version
+(`v\d+(alpha\d+|beta\d+)?`), kind (PascalCase, ≤63, not a reserved name). `errors.go`
+provides `PluginError` with an `ErrorBuilder` and context-specific hint helpers.
+
+## 7. Templates (`pkg/templates/`)
+
+`loader.go` embeds the template tree:
+
+```go
+//go:embed files files/project/.gitignore.tmpl
+var TemplateFS embed.FS
+```
+
+Static-path templates (`apis/`, `cmd/provider/`, `package/`, `project/`, `hack/`, etc.) are
+init/static; path-variable templates (`apis/GROUP/VERSION/`, `internal/controller/KIND/`,
+`examples/GROUP/`) are discovered per API. Kubebuilder's machinery renders Go-template
+actions (`{{ .Boilerplate }}`, `{{ .Resource.Kind }}`) when writing each file.
+
+**To add scaffolding, add a `.tmpl` file under `pkg/templates/files/`** — discovery and
+rendering pick it up automatically; no registration code is needed.
+
+## Design patterns at a glance
+
+| Pattern | Where |
+|---------|-------|
+| Plugin architecture | Kubebuilder v4 plugin (`plugin.go`) |
+| Auto-discovery | `autodiscovery.go` + `factory.go` (FS walk, not static registration) |
+| Strategy | `BuildStrategy` (init / API / static) |
+| Factory | `CrossplaneTemplateFactory` |
+| Builder (fluent) | `FileParserBuilder`, `ErrorBuilder` |
+| Pipeline / chain | `Pipeline` + `Step` |
+| Mixin composition | Kubebuilder machinery mixins in `BaseTemplateProduct` |
+| Embedded FS | `go:embed` template tree |
+
+## Command flow summary
+
+**`init`** → validate inputs → scaffold init + static templates → save PROJECT → init
+pipeline (git init/commit/submodule, `make submodules`, `go mod tidy`, `make generate`,
+`make reviewable`).
+
+**`create api`** → inject & validate resource → build API templates (`{GROUP}`/`{VERSION}`/
+`{KIND}`) → append registration updaters → scaffold → `AddResource` to PROJECT → API-commit
+pipeline (git commit, `make generate`).

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,0 +1,72 @@
+# Development
+
+## Requirements
+
+- **Go 1.26+**
+- **Git**
+- **golangci-lint** — installed automatically by `make lint` if missing
+- **gosec** — security scanner
+
+```bash
+# gosec (macOS)
+brew install gosec
+# gosec (direct)
+go install github.com/securego/gosec/v2/cmd/gosec@latest
+```
+
+## Commands
+
+| Command | Purpose |
+|---------|---------|
+| `make build` | Build `bin/xp-provider-gen` |
+| `make test` | Unit tests with the race detector |
+| `make coverage` | Coverage report at `coverage/coverage.html` |
+| `make fmt` / `make vet` | Format / vet |
+| `make lint` / `make lint-fix` | golangci-lint (config: `.golangci.yml`) |
+| `make gosec` | Security scan |
+| `make mod-tidy` / `make mod-verify` | Module hygiene |
+| `make check` | fmt + vet + lint + gosec + test |
+| `make reviewable` | `mod-tidy` + `check` — run this before pushing |
+| `make e2e-test` | Build, then run the end-to-end scaffold test |
+
+`make reviewable` mirrors what CI enforces. If it passes locally, CI should pass too.
+
+## Typical workflow
+
+1. Make a focused change. Keep it [KISS and DRY](../CLAUDE.md#core-principles).
+2. `make reviewable` — fix anything it reports.
+3. `make e2e-test` if you touched templates, the engine, or the automation pipeline.
+4. Commit with a [conventional commit](https://www.conventionalcommits.org/) message
+   (`feat:`, `fix:`, `refactor:`, `chore:`, `ci:`, `docs:`, `test:`), small and focused.
+5. Open a PR. CI runs lint, tests, e2e, build, and security scans.
+
+## Working with templates
+
+Provider scaffolding lives under `pkg/templates/files/` as `.tmpl` files embedded via
+`go:embed`. They are **auto-discovered** — see [architecture.md](architecture.md#4-template-engine).
+
+To add or change generated output:
+
+1. Add or edit a `.tmpl` file under `pkg/templates/files/`. Path conventions:
+   - Static / per-project files: their real path (e.g. `cmd/provider/main.go.tmpl`).
+   - Per-API files: use the `GROUP`/`VERSION`/`KIND` path placeholders
+     (e.g. `apis/GROUP/VERSION/KIND_types.go.tmpl`).
+2. Use Kubebuilder machinery template actions inside the file (`{{ .Resource.Kind }}`,
+   `{{ .Boilerplate }}`, …) and the path replacements (`{GROUP}`, `{VERSION}`, `{KIND}`,
+   `{IMAGENAME}`).
+3. `make build && make e2e-test` to verify the generated project still builds.
+
+You do **not** register templates in Go code — discovery handles it.
+
+## Coding conventions
+
+- Idiomatic Go, formatted by `gofumpt`/`gci` (run `make lint-fix`).
+- Small, focused files; explicit error wrapping with `fmt.Errorf("...: %w", err)`.
+- No repeated string literals — extract a named constant (the `goconst` linter enforces this).
+- Table-driven tests (see [testing.md](testing.md)).
+
+## CI/CD
+
+Pipelines are documented in [.github/WORKFLOWS.md](../.github/WORKFLOWS.md). All GitHub Actions
+are pinned to commit SHAs (with a version comment) for supply-chain safety; Renovate keeps the
+digests updated.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,0 +1,66 @@
+# Testing
+
+Two layers: fast Go unit tests, and a full end-to-end scaffold test.
+
+## Unit tests
+
+Standard `go test`, table-driven, run with the race detector:
+
+```bash
+make test         # go test -v -race ./...
+make coverage     # writes coverage/coverage.html
+```
+
+Tests live next to the code (`*_test.go`). Pattern:
+
+```go
+tests := []struct {
+    name    string
+    input   string
+    wantErr bool
+}{
+    {name: "valid", input: "example.com", wantErr: false},
+    {name: "empty", input: "", wantErr: true},
+}
+for _, tt := range tests {
+    t.Run(tt.name, func(t *testing.T) {
+        err := validator.ValidateDomain(tt.input)
+        if (err != nil) != tt.wantErr {
+            t.Errorf("ValidateDomain() error = %v, wantErr %v", err, tt.wantErr)
+        }
+    })
+}
+```
+
+Reuse shared literals via constants (keeps tests DRY and satisfies `goconst`).
+
+## End-to-end test
+
+`scripts/e2e-test.sh` (run via `make e2e-test`) exercises the real generator workflow against
+a throwaway project in `/tmp/provider-template`:
+
+1. Build the binary and prepare a clean temp directory.
+2. `init` a provider project; verify the base structure (Makefile, go.mod, apis/, cmd/provider/,
+   internal/controller/).
+3. Run `make submodules`, `make generate`, `make reviewable` on the generated project.
+4. `create api` twice (same group/version, different kinds); verify the generated types and
+   controllers.
+5. Re-run the build targets; verify generated CRDs and examples.
+6. Verify the provider builds.
+
+On **success** the temp project is left in place for inspection (the next run recreates it).
+On **failure** the script removes the incomplete directory and exits non-zero.
+
+```bash
+make e2e-test            # build + run
+./scripts/e2e-test.sh -h # usage
+```
+
+Run the e2e test whenever you change templates, the template engine, or the automation
+pipeline — unit tests alone do not catch broken generated output.
+
+## In CI
+
+Both layers run on every push/PR (see [.github/WORKFLOWS.md](../.github/WORKFLOWS.md)):
+`test.yml` runs unit tests with coverage and the e2e workflow; `lint.yml` and `ci.yml` add
+linting, gosec, and Trivy scanning.

--- a/pkg/plugins/crossplane/v2/templates/engine/api_registration_updater.go
+++ b/pkg/plugins/crossplane/v2/templates/engine/api_registration_updater.go
@@ -111,12 +111,12 @@ func (f *APIRegistrationUpdater) addRegistrationIfNeeded(
 func (f *APIRegistrationUpdater) buildTemplate(imports, registrations []string) string {
 	var importsBuilder strings.Builder
 	for _, imp := range imports {
-		importsBuilder.WriteString(fmt.Sprintf("\t%s\n", imp))
+		fmt.Fprintf(&importsBuilder, "\t%s\n", imp)
 	}
 
 	var registrationsBuilder strings.Builder
 	for _, reg := range registrations {
-		registrationsBuilder.WriteString(fmt.Sprintf("\t\t%s,\n", reg))
+		fmt.Fprintf(&registrationsBuilder, "\t\t%s,\n", reg)
 	}
 
 	return fmt.Sprintf(`{{ .Boilerplate }}

--- a/pkg/plugins/crossplane/v2/templates/engine/builders.go
+++ b/pkg/plugins/crossplane/v2/templates/engine/builders.go
@@ -25,6 +25,9 @@ import (
 	"github.com/cychiang/xp-provider-gen/pkg/plugins/crossplane/v2/core"
 )
 
+// placeholderImageName is the template replacement key for the provider image name.
+const placeholderImageName = "IMAGENAME"
+
 // BuildStrategy defines different strategies for building templates.
 type BuildStrategy interface {
 	GetCategory() TemplateCategory
@@ -95,7 +98,7 @@ func (s *InitBuildStrategy) ValidateOptions(_ *TemplateOptions) error {
 func (s *InitBuildStrategy) GenerateReplacements(cfg config.Config, _ *TemplateOptions) (map[string]string, error) {
 	projectName := core.ExtractProjectName(cfg)
 	return map[string]string{
-		"IMAGENAME": projectName,
+		placeholderImageName: projectName,
 	}, nil
 }
 
@@ -118,10 +121,10 @@ func (s *APIBuildStrategy) GenerateReplacements(
 ) (map[string]string, error) {
 	projectName := core.ExtractProjectName(cfg)
 	return map[string]string{
-		"GROUP":     strings.ToLower(options.Resource.Group),
-		"VERSION":   options.Resource.Version,
-		"KIND":      strings.ToLower(options.Resource.Kind),
-		"IMAGENAME": projectName,
+		"GROUP":              strings.ToLower(options.Resource.Group),
+		"VERSION":            options.Resource.Version,
+		"KIND":               strings.ToLower(options.Resource.Kind),
+		placeholderImageName: projectName,
 	}, nil
 }
 
@@ -142,7 +145,7 @@ func (s *StaticBuildStrategy) GenerateReplacements(
 ) (map[string]string, error) {
 	projectName := core.ExtractProjectName(cfg)
 	replacements := map[string]string{
-		"IMAGENAME": projectName,
+		placeholderImageName: projectName,
 	}
 
 	// Add resource-specific replacements if available

--- a/pkg/plugins/crossplane/v2/templates/engine/template_updater.go
+++ b/pkg/plugins/crossplane/v2/templates/engine/template_updater.go
@@ -152,7 +152,7 @@ func (f *TemplateUpdater) buildImportsSection(imports []string) string {
 	section.WriteString("\t\"github.com/crossplane/crossplane-runtime/v2/pkg/controller\"\n")
 	section.WriteString("\n")
 	for _, imp := range imports {
-		section.WriteString(fmt.Sprintf("\t\"%s\"\n", imp))
+		fmt.Fprintf(&section, "\t\"%s\"\n", imp)
 	}
 	return section.String()
 }
@@ -161,7 +161,7 @@ func (f *TemplateUpdater) buildImportsSection(imports []string) string {
 func (f *TemplateUpdater) buildSetupsSection(setups []string) string {
 	var section strings.Builder
 	for _, setup := range setups {
-		section.WriteString(fmt.Sprintf("\t\t%s,\n", setup))
+		fmt.Fprintf(&section, "\t\t%s,\n", setup)
 	}
 	return section.String()
 }

--- a/pkg/plugins/crossplane/v2/validation/validator.go
+++ b/pkg/plugins/crossplane/v2/validation/validator.go
@@ -24,6 +24,15 @@ import (
 	"sigs.k8s.io/kubebuilder/v4/pkg/model/resource"
 )
 
+// Field names used in validation errors.
+const (
+	fieldDomain     = "domain"
+	fieldRepository = "repository"
+	fieldGroup      = "group"
+	fieldVersion    = "version"
+	fieldKind       = "kind"
+)
+
 // FieldValidationError represents a user input field validation error.
 type FieldValidationError struct {
 	Field   string
@@ -47,7 +56,7 @@ func NewValidator() *Validator {
 func (v *Validator) ValidateDomain(domain string) error {
 	if domain == "" {
 		return FieldValidationError{
-			Field:   "domain",
+			Field:   fieldDomain,
 			Value:   domain,
 			Message: "domain is required",
 		}
@@ -62,7 +71,7 @@ func (v *Validator) ValidateDomain(domain string) error {
 
 	if !matched {
 		return FieldValidationError{
-			Field:   "domain",
+			Field:   fieldDomain,
 			Value:   domain,
 			Message: "must be a valid domain name (e.g., example.com)",
 		}
@@ -71,7 +80,7 @@ func (v *Validator) ValidateDomain(domain string) error {
 	// Prevent common mistakes
 	if strings.HasSuffix(domain, ".local") {
 		return FieldValidationError{
-			Field:   "domain",
+			Field:   fieldDomain,
 			Value:   domain,
 			Message: ".local domains are not recommended for production use",
 		}
@@ -84,7 +93,7 @@ func (v *Validator) ValidateDomain(domain string) error {
 func (v *Validator) ValidateRepository(repo string) error {
 	if repo == "" {
 		return FieldValidationError{
-			Field:   "repository",
+			Field:   fieldRepository,
 			Value:   repo,
 			Message: "repository is required",
 		}
@@ -99,7 +108,7 @@ func (v *Validator) ValidateRepository(repo string) error {
 
 	if !matched {
 		return FieldValidationError{
-			Field:   "repository",
+			Field:   fieldRepository,
 			Value:   repo,
 			Message: "must be a valid go module name (e.g., github.com/example/provider-name)",
 		}
@@ -108,7 +117,7 @@ func (v *Validator) ValidateRepository(repo string) error {
 	// Validate common patterns
 	if !strings.Contains(repo, "/") {
 		return FieldValidationError{
-			Field:   "repository",
+			Field:   fieldRepository,
 			Value:   repo,
 			Message: "must include hosting provider (e.g., github.com/user/repo)",
 		}
@@ -117,7 +126,7 @@ func (v *Validator) ValidateRepository(repo string) error {
 	parts := strings.Split(repo, "/")
 	if len(parts) < 3 {
 		return FieldValidationError{
-			Field:   "repository",
+			Field:   fieldRepository,
 			Value:   repo,
 			Message: "must follow pattern: host/user/repository",
 		}
@@ -161,7 +170,7 @@ func (v *Validator) ValidateResource(res *resource.Resource) error {
 func (v *Validator) validateGroup(group string) error {
 	if group == "" {
 		return FieldValidationError{
-			Field:   "group",
+			Field:   fieldGroup,
 			Value:   group,
 			Message: "group is required",
 		}
@@ -176,7 +185,7 @@ func (v *Validator) validateGroup(group string) error {
 
 	if !matched {
 		return FieldValidationError{
-			Field:   "group",
+			Field:   fieldGroup,
 			Value:   group,
 			Message: "must be lowercase alphanumeric with hyphens (e.g., compute, storage)",
 		}
@@ -185,7 +194,7 @@ func (v *Validator) validateGroup(group string) error {
 	// Length validation following Kubernetes conventions
 	if len(group) > 63 {
 		return FieldValidationError{
-			Field:   "group",
+			Field:   fieldGroup,
 			Value:   group,
 			Message: "must be 63 characters or less",
 		}
@@ -198,7 +207,7 @@ func (v *Validator) validateGroup(group string) error {
 func (v *Validator) validateVersion(version string) error {
 	if version == "" {
 		return FieldValidationError{
-			Field:   "version",
+			Field:   fieldVersion,
 			Value:   version,
 			Message: "version is required",
 		}
@@ -213,7 +222,7 @@ func (v *Validator) validateVersion(version string) error {
 
 	if !matched {
 		return FieldValidationError{
-			Field:   "version",
+			Field:   fieldVersion,
 			Value:   version,
 			Message: "must follow Kubernetes version format (e.g., v1alpha1, v1beta1, v1)",
 		}
@@ -226,7 +235,7 @@ func (v *Validator) validateVersion(version string) error {
 func (v *Validator) validateKind(kind string) error {
 	if kind == "" {
 		return FieldValidationError{
-			Field:   "kind",
+			Field:   fieldKind,
 			Value:   kind,
 			Message: "kind is required",
 		}
@@ -241,7 +250,7 @@ func (v *Validator) validateKind(kind string) error {
 
 	if !matched {
 		return FieldValidationError{
-			Field:   "kind",
+			Field:   fieldKind,
 			Value:   kind,
 			Message: "must be PascalCase (e.g., Instance, Bucket, Database)",
 		}
@@ -250,7 +259,7 @@ func (v *Validator) validateKind(kind string) error {
 	// Length validation
 	if len(kind) > 63 {
 		return FieldValidationError{
-			Field:   "kind",
+			Field:   fieldKind,
 			Value:   kind,
 			Message: "must be 63 characters or less",
 		}
@@ -264,7 +273,7 @@ func (v *Validator) validateKind(kind string) error {
 	for _, reserved := range reservedKinds {
 		if strings.EqualFold(kind, reserved) {
 			return FieldValidationError{
-				Field:   "kind",
+				Field:   fieldKind,
 				Value:   kind,
 				Message: fmt.Sprintf("'%s' is a reserved Kubernetes resource name", reserved),
 			}

--- a/pkg/plugins/crossplane/v2/validation_test.go
+++ b/pkg/plugins/crossplane/v2/validation_test.go
@@ -22,6 +22,13 @@ import (
 	"sigs.k8s.io/kubebuilder/v4/pkg/model/resource"
 )
 
+// Sample GVK values reused across validation test cases.
+const (
+	testGroup   = "compute"
+	testVersion = "v1alpha1"
+	testKind    = "Instance"
+)
+
 func TestValidator_ValidateDomain(t *testing.T) {
 	validator := NewValidator()
 
@@ -134,9 +141,9 @@ func TestValidator_ValidateResource(t *testing.T) {
 			name: "valid resource",
 			resource: &resource.Resource{
 				GVK: resource.GVK{
-					Group:   "compute",
-					Version: "v1alpha1",
-					Kind:    "Instance",
+					Group:   testGroup,
+					Version: testVersion,
+					Kind:    testKind,
 				},
 			},
 			wantErr: false,
@@ -162,8 +169,8 @@ func TestValidator_ValidateResource(t *testing.T) {
 			resource: &resource.Resource{
 				GVK: resource.GVK{
 					Group:   "",
-					Version: "v1alpha1",
-					Kind:    "Instance",
+					Version: testVersion,
+					Kind:    testKind,
 				},
 			},
 			wantErr: true,
@@ -172,9 +179,9 @@ func TestValidator_ValidateResource(t *testing.T) {
 			name: "invalid version",
 			resource: &resource.Resource{
 				GVK: resource.GVK{
-					Group:   "compute",
+					Group:   testGroup,
 					Version: "alpha1",
-					Kind:    "Instance",
+					Kind:    testKind,
 				},
 			},
 			wantErr: true,
@@ -183,8 +190,8 @@ func TestValidator_ValidateResource(t *testing.T) {
 			name: "invalid kind",
 			resource: &resource.Resource{
 				GVK: resource.GVK{
-					Group:   "compute",
-					Version: "v1alpha1",
+					Group:   testGroup,
+					Version: testVersion,
 					Kind:    "instance",
 				},
 			},
@@ -194,8 +201,8 @@ func TestValidator_ValidateResource(t *testing.T) {
 			name: "reserved kind",
 			resource: &resource.Resource{
 				GVK: resource.GVK{
-					Group:   "compute",
-					Version: "v1alpha1",
+					Group:   testGroup,
+					Version: testVersion,
 					Kind:    "Pod",
 				},
 			},

--- a/renovate.json
+++ b/renovate.json
@@ -2,6 +2,7 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended",
+    "helpers:pinGitHubActionDigests",
     ":enableVulnerabilityAlertsWithLabel(security)",
     ":rebaseStalePrs",
     ":semanticCommitTypeAll(chore)"

--- a/scripts/e2e-test.sh
+++ b/scripts/e2e-test.sh
@@ -235,9 +235,9 @@ main() {
 
     # Show final project structure
     log_info "Final project structure:"
-    find . -type f -name "*.go" -o -name "*.yaml" -o -name "Makefile" -o -name "go.mod" | \
-        head -20 | \
+    find . -type f \( -name "*.go" -o -name "*.yaml" -o -name "Makefile" -o -name "go.mod" \) | \
         sort | \
+        head -20 | \
         sed 's/^/  /'
 
     if [[ $(find . -type f \( -name "*.go" -o -name "*.yaml" \) | wc -l) -gt 20 ]]; then
@@ -273,15 +273,20 @@ if [[ "$1" == "--help" || "$1" == "-h" ]]; then
     exit 0
 fi
 
-# Cleanup function
-cleanup() {
-    log_info "Cleaning up test directory..."
-    rm -rf "$TEST_DIR"
-    log_success "Test directory cleaned up"
+# On failure: remove the (likely incomplete) test directory so the next run
+# starts clean. On success: keep it so the generated provider can be inspected
+# (the next run recreates it from scratch anyway). This keeps the final
+# "Test artifacts available at: $TEST_DIR" message truthful.
+on_exit() {
+    local exit_code=$?
+    if [[ $exit_code -ne 0 ]]; then
+        log_error "E2E test failed"
+        log_info "Cleaning up incomplete test directory..."
+        rm -rf "$TEST_DIR"
+    fi
 }
 
-# Trap to ensure cleanup on exit
-trap 'if [[ $? -ne 0 ]]; then log_error "E2E test failed"; fi; cleanup' EXIT
+trap on_exit EXIT
 
 # Run the main test
 main


### PR DESCRIPTION
Applies KISS and DRY across the repo, fixes pre-existing CI/lint debt on `main`, and restructures project documentation.

## Why
Running the current toolchain on `main` surfaced real issues the stale green PR checks hid:
- `golangci-lint` v2.12 fails on `main` (`goconst` / `staticcheck` debt).
- The `Security Scan` job fails on every fresh run: `aquasecurity/trivy-action@0.33.1` is unresolvable (real tag is `v0.33.1`).
- The Makefile had a dead `integration-test` target (missing script) and a `docs` placeholder pointing at a non-existent file.

## What's in here
- **refactor (DRY/lint):** extract repeated string literals to constants (`goconst`), replace `WriteString(fmt.Sprintf(...))` with `fmt.Fprintf` (`staticcheck QF1012`), migrate deprecated `gomodguard` → `gomodguard_v2`.
- **chore (KISS):** remove dead Makefile targets + duplicate echo; fix `e2e-test.sh` so it only deletes the temp dir on failure (the success summary claimed artifacts remained, but the trap always deleted them).
- **ci (security):** pin **all** GitHub Actions to commit SHAs (with version comments) to prevent tag-hijack supply-chain attacks; fix the broken trivy pin; add `helpers:pinGitHubActionDigests` so Renovate keeps digests updated. SHAs are the latest release within each action's current major — pure security, no behavioral major jump.
- **docs:** new concise `CLAUDE.md` (KISS/DRY principles up front) + `docs/{architecture,development,testing}.md`; trim duplicated developer sections from the README to point at `docs/`.

## Verification
`make build`, `go test ./...`, and `golangci-lint run` all pass locally (0 lint issues).

> Note: a newer local gosec (2.27.1) flags 5 pre-existing `G204` (subprocess-with-variable) findings in `core/command_runner.go` and `core/git_runner.go`. CI's pinned gosec (2.22.10) does not flag them; they are inherent to a generator that shells out to git/go/make and are out of scope for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)