### PR TITLE
fix(pipeline): generate-then-commit; clean tree after init/create api

### DIFF
--- a/pkg/plugins/crossplane/v2/automation/pipeline.go
+++ b/pkg/plugins/crossplane/v2/automation/pipeline.go
@@ -34,12 +34,12 @@ Scaffolded Crossplane provider project for %s`, providerName)
 	return &Pipeline{
 		steps: []Step{
 			NewGitInitStep(config),
-			NewGitCommitStep(config, commitMessage),
 			NewGitSubmoduleStep(config),
-			NewMakeStep("submodules", false),
-			NewGoModTidyStep(false),
-			NewMakeStep("generate", false),
-			NewMakeStep("reviewable", false),
+			NewMakeStep("submodules", true),
+			NewGoModTidyStep(true),
+			NewMakeStep("generate", true),
+			NewMakeStep("reviewable", true),
+			NewGitCommitStep(config, commitMessage),
 		},
 	}
 }
@@ -51,8 +51,8 @@ Scaffolded CRD, controller, and client code for %s resource`, resourceKind, reso
 
 	return &Pipeline{
 		steps: []Step{
+			NewMakeStep("generate", true),
 			NewGitCommitStep(config, commitMessage),
-			NewMakeStep("generate", false),
 		},
 	}
 }

--- a/pkg/plugins/crossplane/v2/automation/pipeline.go
+++ b/pkg/plugins/crossplane/v2/automation/pipeline.go
@@ -35,10 +35,10 @@ Scaffolded Crossplane provider project for %s`, providerName)
 		steps: []Step{
 			NewGitInitStep(config),
 			NewGitSubmoduleStep(config),
-			NewMakeStep("submodules", true),
-			NewGoModTidyStep(true),
-			NewMakeStep("generate", true),
-			NewMakeStep("reviewable", true),
+			NewMakeStep("submodules"),
+			NewGoModTidyStep(),
+			NewMakeStep("generate"),
+			NewMakeStep("reviewable"),
 			NewGitCommitStep(config, commitMessage),
 		},
 	}
@@ -51,7 +51,7 @@ Scaffolded CRD, controller, and client code for %s resource`, resourceKind, reso
 
 	return &Pipeline{
 		steps: []Step{
-			NewMakeStep("generate", true),
+			NewMakeStep("generate"),
 			NewGitCommitStep(config, commitMessage),
 		},
 	}
@@ -62,10 +62,7 @@ func (p *Pipeline) Run() error {
 		fmt.Printf("  %d. %s...\n", i+1, step.Name())
 
 		if err := step.Execute(); err != nil {
-			if step.IsRequired() {
-				return fmt.Errorf("%s failed (required): %w", step.Name(), err)
-			}
-			fmt.Printf("    Warning: %s: %v (continuing...)\n", step.Name(), err)
+			return fmt.Errorf("%s failed: %w", step.Name(), err)
 		}
 	}
 

--- a/pkg/plugins/crossplane/v2/automation/pipeline_test.go
+++ b/pkg/plugins/crossplane/v2/automation/pipeline_test.go
@@ -17,10 +17,21 @@ limitations under the License.
 package automation
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/cychiang/xp-provider-gen/pkg/plugins/crossplane/v2/core"
 )
+
+// fakeStep records whether it ran and optionally fails.
+type fakeStep struct {
+	name string
+	err  error
+	ran  *bool
+}
+
+func (s fakeStep) Name() string   { return s.name }
+func (s fakeStep) Execute() error { *s.ran = true; return s.err }
 
 func stepNames(p *Pipeline) []string {
 	names := make([]string, 0, len(p.steps))
@@ -66,4 +77,24 @@ func TestNewAPICommitPipeline_CommitsLast(t *testing.T) {
 		"Run make generate",
 		stepNameInitialCommit,
 	})
+}
+
+func TestPipeline_Run_AbortsOnFirstFailure(t *testing.T) {
+	firstRan, secondRan := false, false
+	wantErr := errors.New("boom")
+	p := &Pipeline{steps: []Step{
+		fakeStep{name: "first", err: wantErr, ran: &firstRan},
+		fakeStep{name: "second", ran: &secondRan},
+	}}
+
+	err := p.Run()
+	if err == nil || !errors.Is(err, wantErr) {
+		t.Fatalf("Run() error = %v, want wrapped %v", err, wantErr)
+	}
+	if !firstRan {
+		t.Error("first step should have run")
+	}
+	if secondRan {
+		t.Error("second step must not run after a failure")
+	}
 }

--- a/pkg/plugins/crossplane/v2/automation/pipeline_test.go
+++ b/pkg/plugins/crossplane/v2/automation/pipeline_test.go
@@ -30,15 +30,6 @@ func stepNames(p *Pipeline) []string {
 	return names
 }
 
-func allRequired(p *Pipeline) bool {
-	for _, s := range p.steps {
-		if !s.IsRequired() {
-			return false
-		}
-	}
-	return true
-}
-
 func assertStepOrder(t *testing.T, p *Pipeline, want []string) {
 	t.Helper()
 	got := stepNames(p)
@@ -52,7 +43,7 @@ func assertStepOrder(t *testing.T, p *Pipeline, want []string) {
 	}
 }
 
-func TestNewInitPipeline_CommitsLastAndAllRequired(t *testing.T) {
+func TestNewInitPipeline_CommitsLast(t *testing.T) {
 	cfg := core.NewPluginConfig("crossplane")
 	p := NewInitPipeline(cfg, "provider-test")
 
@@ -65,12 +56,9 @@ func TestNewInitPipeline_CommitsLastAndAllRequired(t *testing.T) {
 		"Run make reviewable",
 		stepNameInitialCommit,
 	})
-	if !allRequired(p) {
-		t.Error("all init pipeline steps must be required")
-	}
 }
 
-func TestNewAPICommitPipeline_CommitsLastAndAllRequired(t *testing.T) {
+func TestNewAPICommitPipeline_CommitsLast(t *testing.T) {
 	cfg := core.NewPluginConfig("crossplane")
 	p := NewAPICommitPipeline(cfg, "Bucket")
 
@@ -78,7 +66,4 @@ func TestNewAPICommitPipeline_CommitsLastAndAllRequired(t *testing.T) {
 		"Run make generate",
 		stepNameInitialCommit,
 	})
-	if !allRequired(p) {
-		t.Error("all api pipeline steps must be required")
-	}
 }

--- a/pkg/plugins/crossplane/v2/automation/pipeline_test.go
+++ b/pkg/plugins/crossplane/v2/automation/pipeline_test.go
@@ -1,0 +1,84 @@
+/*
+Copyright 2025 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package automation
+
+import (
+	"testing"
+
+	"github.com/cychiang/xp-provider-gen/pkg/plugins/crossplane/v2/core"
+)
+
+func stepNames(p *Pipeline) []string {
+	names := make([]string, 0, len(p.steps))
+	for _, s := range p.steps {
+		names = append(names, s.Name())
+	}
+	return names
+}
+
+func allRequired(p *Pipeline) bool {
+	for _, s := range p.steps {
+		if !s.IsRequired() {
+			return false
+		}
+	}
+	return true
+}
+
+func assertStepOrder(t *testing.T, p *Pipeline, want []string) {
+	t.Helper()
+	got := stepNames(p)
+	if len(got) != len(want) {
+		t.Fatalf("step count = %d, want %d (%v)", len(got), len(want), got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("step %d = %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
+func TestNewInitPipeline_CommitsLastAndAllRequired(t *testing.T) {
+	cfg := core.NewPluginConfig("crossplane")
+	p := NewInitPipeline(cfg, "provider-test")
+
+	assertStepOrder(t, p, []string{
+		"Initialize git repository",
+		"Add build submodule from " + cfg.Git.BuildSubmoduleURL,
+		"Run make submodules",
+		"Download dependencies (go mod tidy)",
+		"Run make generate",
+		"Run make reviewable",
+		stepNameInitialCommit,
+	})
+	if !allRequired(p) {
+		t.Error("all init pipeline steps must be required")
+	}
+}
+
+func TestNewAPICommitPipeline_CommitsLastAndAllRequired(t *testing.T) {
+	cfg := core.NewPluginConfig("crossplane")
+	p := NewAPICommitPipeline(cfg, "Bucket")
+
+	assertStepOrder(t, p, []string{
+		"Run make generate",
+		stepNameInitialCommit,
+	})
+	if !allRequired(p) {
+		t.Error("all api pipeline steps must be required")
+	}
+}

--- a/pkg/plugins/crossplane/v2/automation/steps.go
+++ b/pkg/plugins/crossplane/v2/automation/steps.go
@@ -29,6 +29,9 @@ type Step interface {
 	IsRequired() bool
 }
 
+// stepNameInitialCommit is the display name of the commit step.
+const stepNameInitialCommit = "Create initial commit"
+
 type GitInitStep struct {
 	git      *GitOperations
 	required bool
@@ -37,7 +40,7 @@ type GitInitStep struct {
 func NewGitInitStep(config *core.PluginConfig) *GitInitStep {
 	return &GitInitStep{
 		git:      NewGitOperations(config),
-		required: false,
+		required: true,
 	}
 }
 
@@ -65,12 +68,12 @@ func NewGitCommitStep(config *core.PluginConfig, message string) *GitCommitStep 
 		git:      NewGitOperations(config),
 		message:  message,
 		author:   "", // Empty to use system git config, fallback to default in CreateCommit
-		required: false,
+		required: true,
 	}
 }
 
 func (s *GitCommitStep) Name() string {
-	return "Create initial commit"
+	return stepNameInitialCommit
 }
 
 func (s *GitCommitStep) Execute() error {
@@ -93,7 +96,7 @@ func NewGitSubmoduleStep(config *core.PluginConfig) *GitSubmoduleStep {
 		git:      NewGitOperations(config),
 		url:      config.Git.BuildSubmoduleURL,
 		path:     "build",
-		required: false,
+		required: true,
 	}
 }
 

--- a/pkg/plugins/crossplane/v2/automation/steps.go
+++ b/pkg/plugins/crossplane/v2/automation/steps.go
@@ -23,25 +23,22 @@ import (
 	"github.com/cychiang/xp-provider-gen/pkg/plugins/crossplane/v2/core"
 )
 
+// Step is a single unit of post-scaffold automation. Every step is required:
+// a failure aborts the pipeline (see Pipeline.Run).
 type Step interface {
 	Name() string
 	Execute() error
-	IsRequired() bool
 }
 
 // stepNameInitialCommit is the display name of the commit step.
 const stepNameInitialCommit = "Create initial commit"
 
 type GitInitStep struct {
-	git      *GitOperations
-	required bool
+	git *GitOperations
 }
 
 func NewGitInitStep(config *core.PluginConfig) *GitInitStep {
-	return &GitInitStep{
-		git:      NewGitOperations(config),
-		required: true,
-	}
+	return &GitInitStep{git: NewGitOperations(config)}
 }
 
 func (s *GitInitStep) Name() string {
@@ -52,23 +49,17 @@ func (s *GitInitStep) Execute() error {
 	return s.git.Init(context.Background())
 }
 
-func (s *GitInitStep) IsRequired() bool {
-	return s.required
-}
-
 type GitCommitStep struct {
-	git      *GitOperations
-	message  string
-	author   string
-	required bool
+	git     *GitOperations
+	message string
+	author  string
 }
 
 func NewGitCommitStep(config *core.PluginConfig, message string) *GitCommitStep {
 	return &GitCommitStep{
-		git:      NewGitOperations(config),
-		message:  message,
-		author:   "", // Empty to use system git config, fallback to default in CreateCommit
-		required: true,
+		git:     NewGitOperations(config),
+		message: message,
+		author:  "", // Empty to use system git config, fallback to default in CreateCommit
 	}
 }
 
@@ -80,23 +71,17 @@ func (s *GitCommitStep) Execute() error {
 	return s.git.CreateCommit(context.Background(), s.message, s.author)
 }
 
-func (s *GitCommitStep) IsRequired() bool {
-	return s.required
-}
-
 type GitSubmoduleStep struct {
-	git      *GitOperations
-	url      string
-	path     string
-	required bool
+	git  *GitOperations
+	url  string
+	path string
 }
 
 func NewGitSubmoduleStep(config *core.PluginConfig) *GitSubmoduleStep {
 	return &GitSubmoduleStep{
-		git:      NewGitOperations(config),
-		url:      config.Git.BuildSubmoduleURL,
-		path:     "build",
-		required: true,
+		git:  NewGitOperations(config),
+		url:  config.Git.BuildSubmoduleURL,
+		path: "build",
 	}
 }
 
@@ -108,20 +93,12 @@ func (s *GitSubmoduleStep) Execute() error {
 	return s.git.AddSubmodule(context.Background(), s.url, s.path)
 }
 
-func (s *GitSubmoduleStep) IsRequired() bool {
-	return s.required
-}
-
 type MakeStep struct {
-	target   string
-	required bool
+	target string
 }
 
-func NewMakeStep(target string, required bool) *MakeStep {
-	return &MakeStep{
-		target:   target,
-		required: required,
-	}
+func NewMakeStep(target string) *MakeStep {
+	return &MakeStep{target: target}
 }
 
 func (s *MakeStep) Name() string {
@@ -132,18 +109,10 @@ func (s *MakeStep) Execute() error {
 	return core.NewCommandRunner("").Run(context.Background(), "make", s.target)
 }
 
-func (s *MakeStep) IsRequired() bool {
-	return s.required
-}
+type GoModTidyStep struct{}
 
-type GoModTidyStep struct {
-	required bool
-}
-
-func NewGoModTidyStep(required bool) *GoModTidyStep {
-	return &GoModTidyStep{
-		required: required,
-	}
+func NewGoModTidyStep() *GoModTidyStep {
+	return &GoModTidyStep{}
 }
 
 func (s *GoModTidyStep) Name() string {
@@ -152,8 +121,4 @@ func (s *GoModTidyStep) Name() string {
 
 func (s *GoModTidyStep) Execute() error {
 	return core.NewCommandRunner("").Run(context.Background(), "go", "mod", "tidy")
-}
-
-func (s *GoModTidyStep) IsRequired() bool {
-	return s.required
 }

--- a/scripts/e2e-test.sh
+++ b/scripts/e2e-test.sh
@@ -85,6 +85,19 @@ verify_files_exist() {
     log_success "All $description files verified"
 }
 
+assert_clean_tree() {
+    local context=$1
+    log_info "Asserting clean git tree after $context..."
+    local dirty
+    dirty="$(git status --porcelain)"
+    if [[ -n "$dirty" ]]; then
+        log_error "Working tree is dirty after $context:"
+        echo "$dirty"
+        return 1
+    fi
+    log_success "Working tree is clean after $context"
+}
+
 # Main test function
 main() {
     log_info "Starting local E2E test for xp-provider-gen"
@@ -151,6 +164,9 @@ main() {
 
     log_success "All initial build targets completed successfully"
 
+    # The init pipeline must leave a clean, fully-committed tree.
+    assert_clean_tree "init"
+
     # Step 4: Create first API (MyType)
     step_header "4" "Create first API: $GROUP/$VERSION $KIND1"
 
@@ -213,6 +229,9 @@ main() {
     run_make_target "reviewable"
 
     log_success "All build targets after API creation completed successfully"
+
+    # Adding APIs must also leave a clean, fully-committed tree.
+    assert_clean_tree "create api"
 
     # Step 7: Final verification
     step_header "7" "Final verification"


### PR DESCRIPTION
**PR 1 of the [provider-generation upgradability roadmap](../blob/main/docs/superpowers/plans/2026-06-11-provider-generation-upgradability-roadmap.md)** (spec: #45).

## Problem
The init/create-api pipelines committed *before* running submodules / `go mod tidy` / `make generate` / `make reviewable`, so every generated provider was left with a dirty working tree and an incomplete "Initial commit". All steps were also non-required, so generation could silently fail yet report success.

## Change
- **Reorder** both pipelines so the git commit is **last**, capturing the fully generated, formatted tree.
- **Every step is required** — a failure aborts with a wrapped error instead of warn-and-continue. Since requiredness is now universal, the per-step `required` flag / `IsRequired()` / the dead warn-and-continue branch are removed (KISS, via `/simplify`).
- **e2e regression guard**: assert `git status --porcelain` is clean after `init` and after `create api`.

## Tests
- `pipeline_test.go`: step order for both pipelines; `Run()` aborts on first failure (wrapped error, later steps skipped).
- e2e: clean-tree assertions (verified locally — both pass end-to-end on Go 1.26).

## Quality gates
`/simplify` (removed the vestigial required mechanism) and `/code-review` (no CRITICAL/HIGH; added the `Run()` test it flagged) both run. `make build`/`test`/`lint` green locally.

Scope: this is the "generate-then-commit" half for `init`/`create api`. `update`'s no-commit behavior is a later PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)