### PR TITLE
feat: fold initial scaffolding into a single Initial commit

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,11 @@ make generate && make build && make reviewable
 
 > **Important:** Always run `init` in a separate directory to avoid polluting your workspace.
 
+> **Single initial commit:** `init` + each `create api` fold into one `Initial commit` while the
+> provider is still being scaffolded. Finish scaffolding (and make your first own commit) **before
+> pushing** — folding uses `git --amend`, so pushing mid-scaffold would require a force-push. Once
+> you've committed your own work, later `create api` runs add separate commits.
+
 ## Commands
 
 ### `init` - Initialize provider project

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -169,6 +169,10 @@ commit).
 
 **`create api`** → inject & validate resource → render API templates + **regenerate register
 files** from all resources → `AddResource` to PROJECT → API-commit pipeline (generate, commit).
+While the history is still just the tool's scaffold (the `Initial commit` carries the
+`xp-provider-gen-scaffold` trailer and the user hasn't committed yet), the commit **folds into
+that `Initial commit`** via `--amend`, so a freshly scaffolded provider has a single commit;
+once the user commits their own work, later `create api` runs add separate commits.
 
 **`update`** → require clean tree → render to memfs → reconcile via the ownership gate → bump
 deps via `go get` → tidy/generate/reviewable → stamp provenance (no commit; review the diff).

--- a/pkg/plugins/crossplane/v2/automation/git.go
+++ b/pkg/plugins/crossplane/v2/automation/git.go
@@ -89,6 +89,12 @@ func (g *GitOperations) CreateCommit(ctx context.Context, message, author string
 // while HEAD still carries the scaffold trailer (the provider is still in initial
 // setup); otherwise it creates a new commit. This keeps a freshly scaffolded
 // provider at one "Initial commit" until the user makes their own commit.
+//
+// The fold rewrites HEAD via --amend and stages the whole working tree, so it
+// assumes the intended workflow: scaffold the provider fully (init + create api)
+// before pushing or making your own commit, and don't run create-api with
+// unrelated unstaged edits you don't want folded into the Initial commit. Once
+// you commit your own work, create-api stops folding and adds separate commits.
 func (g *GitOperations) CommitOrAmendScaffold(ctx context.Context, message, author string) error {
 	if err := g.runner.Add(ctx, "."); err != nil {
 		return err

--- a/pkg/plugins/crossplane/v2/automation/git.go
+++ b/pkg/plugins/crossplane/v2/automation/git.go
@@ -19,9 +19,16 @@ package automation
 import (
 	"context"
 	"os"
+	"strings"
 
 	"github.com/cychiang/xp-provider-gen/pkg/plugins/crossplane/v2/core"
 )
+
+// ScaffoldCommitTrailer marks the initial scaffold commit. While HEAD carries it
+// (i.e. the user hasn't committed their own work yet), `create api` folds into
+// that commit instead of adding a new one, so a freshly scaffolded provider has a
+// single "Initial commit".
+const ScaffoldCommitTrailer = "xp-provider-gen-scaffold: true"
 
 type GitOperations struct {
 	config *core.PluginConfig
@@ -76,6 +83,34 @@ func (g *GitOperations) CreateCommit(ctx context.Context, message, author string
 
 	// Use project's local git config (set during Init)
 	return g.runner.CommitWithSystemAuthor(ctx, message)
+}
+
+// CommitOrAmendScaffold folds the staged change into the existing scaffold commit
+// while HEAD still carries the scaffold trailer (the provider is still in initial
+// setup); otherwise it creates a new commit. This keeps a freshly scaffolded
+// provider at one "Initial commit" until the user makes their own commit.
+func (g *GitOperations) CommitOrAmendScaffold(ctx context.Context, message, author string) error {
+	if err := g.runner.Add(ctx, "."); err != nil {
+		return err
+	}
+	if g.headIsScaffold(ctx) {
+		// Keep the Initial commit's message and author; just add the new files.
+		return g.runner.RunCommand(ctx, "commit", "--amend", "--no-edit")
+	}
+	if author != "" {
+		return g.runner.CommitWithAuthor(ctx, message, author)
+	}
+	return g.runner.CommitWithSystemAuthor(ctx, message)
+}
+
+// headIsScaffold reports whether the current HEAD commit is the tool's scaffold
+// commit (carries the trailer and the user hasn't committed since).
+func (g *GitOperations) headIsScaffold(ctx context.Context) bool {
+	out, err := g.runner.RunCommandWithOutput(ctx, "log", "-1", "--pretty=%B")
+	if err != nil {
+		return false // no commits yet — make a normal commit
+	}
+	return strings.Contains(out, ScaffoldCommitTrailer)
 }
 
 func (g *GitOperations) AddSubmodule(ctx context.Context, url, path string) error {

--- a/pkg/plugins/crossplane/v2/automation/pipeline.go
+++ b/pkg/plugins/crossplane/v2/automation/pipeline.go
@@ -29,7 +29,9 @@ type Pipeline struct {
 func NewInitPipeline(config *core.PluginConfig, providerName string) *Pipeline {
 	commitMessage := fmt.Sprintf(`Initial commit
 
-Scaffolded Crossplane provider project for %s`, providerName)
+Scaffolded Crossplane provider project for %s
+
+%s`, providerName, ScaffoldCommitTrailer)
 
 	return &Pipeline{
 		steps: []Step{
@@ -52,7 +54,7 @@ Scaffolded CRD, controller, and client code for %s resource`, resourceKind, reso
 	return &Pipeline{
 		steps: []Step{
 			NewMakeStep("generate"),
-			NewGitCommitStep(config, commitMessage),
+			NewGitFoldCommitStep(config, commitMessage),
 		},
 	}
 }

--- a/pkg/plugins/crossplane/v2/automation/pipeline_test.go
+++ b/pkg/plugins/crossplane/v2/automation/pipeline_test.go
@@ -75,7 +75,7 @@ func TestNewAPICommitPipeline_CommitsLast(t *testing.T) {
 
 	assertStepOrder(t, p, []string{
 		"Run make generate",
-		stepNameInitialCommit,
+		"Commit changes (fold into initial scaffold if applicable)",
 	})
 }
 

--- a/pkg/plugins/crossplane/v2/automation/steps.go
+++ b/pkg/plugins/crossplane/v2/automation/steps.go
@@ -71,6 +71,30 @@ func (s *GitCommitStep) Execute() error {
 	return s.git.CreateCommit(context.Background(), s.message, s.author)
 }
 
+// GitFoldCommitStep commits, folding into the initial scaffold commit while the
+// provider is still in initial setup (see GitOperations.CommitOrAmendScaffold).
+type GitFoldCommitStep struct {
+	git     *GitOperations
+	message string
+	author  string
+}
+
+func NewGitFoldCommitStep(config *core.PluginConfig, message string) *GitFoldCommitStep {
+	return &GitFoldCommitStep{
+		git:     NewGitOperations(config),
+		message: message,
+		author:  "",
+	}
+}
+
+func (s *GitFoldCommitStep) Name() string {
+	return "Commit changes (fold into initial scaffold if applicable)"
+}
+
+func (s *GitFoldCommitStep) Execute() error {
+	return s.git.CommitOrAmendScaffold(context.Background(), s.message, s.author)
+}
+
 type GitSubmoduleStep struct {
 	git  *GitOperations
 	url  string

--- a/scripts/e2e-test.sh
+++ b/scripts/e2e-test.sh
@@ -272,6 +272,17 @@ main() {
     # Adding APIs must also leave a clean, fully-committed tree.
     assert_clean_tree "create api"
 
+    # Initial scaffolding (init + create api x2) folds into a single commit.
+    log_info "Asserting initial scaffolding is a single commit..."
+    commit_count="$(git rev-list --count HEAD)"
+    if [[ "$commit_count" == "1" && "$(git log -1 --format=%s)" == "Initial commit" ]]; then
+        log_success "✓ init + create api folded into one 'Initial commit'"
+    else
+        log_error "✗ expected a single 'Initial commit', found $commit_count commit(s):"
+        git log --oneline
+        exit 1
+    fi
+
     # Step U: the update command refreshes tool-owned files without touching user logic
     step_header "U" "Test update command"
     local ctrl="internal/controller/${KIND1_LOWER}/controller.go"


### PR DESCRIPTION
A freshly scaffolded provider now starts as **one `Initial commit`** instead of one commit per `init`/`create api`.

## How
- `init`'s `Initial commit` carries an `xp-provider-gen-scaffold: true` trailer.
- While HEAD still carries that trailer (the user hasn't committed their own work yet), `create api` **folds** its changes into the Initial commit via `git commit --amend --no-edit` (`GitOperations.CommitOrAmendScaffold`).
- Once you make your own commit, the trailer is no longer on HEAD, so later `create api` runs add **separate** commits — your history is never amended.

## Why
Per request: `init` + `create api ×N` produced N+1 commits; a fresh scaffold should read as a single initial setup. (The clean-tree guarantee from #46 is preserved — the fold still leaves a clean, committed tree.)

## Tests
- Unit: API pipeline uses the fold step.
- **e2e:** asserts `init` + `create api ×2` yields exactly one `Initial commit`; the `update`/`update --adopt` scenarios still pass.

## Quality gates
`/code-review`: core logic correct (trailer survives folds; new commit after the user commits; no empty-commit/author-drift issues). Two MEDIUM findings were about the intended workflow — addressed by documenting the precondition (scaffold fully before pushing; the fold stages the whole tree) in the `CommitOrAmendScaffold` doc comment and the README. `/simplify`: the dedicated `GitFoldCommitStep` is self-documenting (kept distinct from `GitCommitStep`). Build/test/lint + full e2e green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)