### PR TITLE
ci(renovate): group generated-provider framework deps to stop e2e-breaking individual bumps

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -161,6 +161,16 @@
       "semanticCommitScope": "docker",
       "prPriority": 6,
       "minimumReleaseAge": "10 days"
+    },
+    {
+      "description": "Generated-provider framework deps (pkg/versions/dependencies.yaml) - bump together so crossplane-runtime, controller-runtime, and k8s.io/* stay mutually compatible (individual bumps break the e2e)",
+      "matchFileNames": ["pkg/versions/dependencies.yaml"],
+      "groupName": "provider framework dependencies",
+      "addLabels": ["dependencies", "provider-framework"],
+      "semanticCommitType": "deps",
+      "semanticCommitScope": "provider",
+      "prPriority": 14,
+      "minimumReleaseAge": "7 days"
     }
   ],
   "customManagers": [


### PR DESCRIPTION
**Root-cause fix for the recurring failing Renovate PRs.** #58, #60, and #66 all failed the e2e and were closed because Renovate bumped a single framework dependency in `pkg/versions/dependencies.yaml` (e.g. controller-runtime alone, or crossplane-runtime alone), skewing it against the others.

This adds a `matchFileNames` rule that groups **everything in `pkg/versions/dependencies.yaml`** (crossplane-runtime, controller-runtime, `k8s.io/*`) into one **"provider framework dependencies"** PR, so they bump together as a coordinated set the e2e can actually validate.

No code change; `renovate.json` only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)