### PR TITLE
deps(provider): bump crossplane-runtime to v2.2.2 (the toolchain-compatible version)

### DIFF
--- a/pkg/versions/dependencies.yaml
+++ b/pkg/versions/dependencies.yaml
@@ -10,7 +10,7 @@ dependencies:
   - module: github.com/alecthomas/kingpin/v2
     version: v2.4.0
   - module: github.com/crossplane/crossplane-runtime/v2
-    version: v2.0.0
+    version: v2.2.2
   - module: github.com/google/go-cmp
     version: v0.7.0
   - module: github.com/pkg/errors
@@ -18,8 +18,8 @@ dependencies:
   - module: google.golang.org/grpc
     version: v1.81.1
   - module: k8s.io/apimachinery
-    version: v0.33.3
+    version: v0.35.0
   - module: k8s.io/client-go
-    version: v0.33.3
+    version: v0.35.0
   - module: sigs.k8s.io/controller-runtime
-    version: v0.21.0
+    version: v0.23.1


### PR DESCRIPTION
Fixes the failing framework-dependency bump (Renovate #74 / closed #70/#58/#66). Renovate kept proposing **crossplane-runtime v2.3.x**, which fails the e2e — so I traced *why* and bumped to the latest version that actually works.

## Root cause (why v2.3 fails)
- crossplane-runtime **v2.3 moved `apis/common/*`** into a separate module (`github.com/crossplane/crossplane/apis`).
- **crossplane-tools/angryjet** (latest, Oct 2025) detects managed resources by **hardcoded type paths** (`.../crossplane-runtime/v2/apis/common/v2.ManagedResourceSpec`, etc.). It doesn't know the new location, so it generates **no methodsets** → the provider fails `resource.Managed`/`ModernManaged` (`missing GetCondition`/`GetProviderConfigReference`/`GetItems`).
- Upstream `provider-template` is also **still on v2.0.0**. The v2.3 codegen toolchain hasn't caught up.

## The fix
Bump to **crossplane-runtime v2.2.2** — the latest version that still ships `apis/common` (so angryjet works) — with the compatible set it builds against: **k8s 0.35.0, controller-runtime 0.23.1**. **No template changes needed.** Renovate's "latest of each" (k8s 0.36 / controller-runtime 0.24 / runtime 2.3) was a skewed, unbuildable set.

## Verified
Full `make e2e-test` passes: init → create api ×2 → generate → reviewable → build, single Initial commit, update/adopt. Generated go.mod resolves to crossplane-runtime v2.2.2 + k8s 0.35.0 + controller-runtime 0.23.1.

The v2.3 import migration (which is correct but blocked on the toolchain) is preserved on `feat/crossplane-runtime-2.3` for when angryjet/provider-template support v2.3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)