### PR TITLE
deps(provider): bump k8s to v0.36.1 and controller-runtime to v0.24.1 (hold crossplane-runtime at v2.2.x)

### DIFF
--- a/pkg/versions/dependencies.yaml
+++ b/pkg/versions/dependencies.yaml
@@ -18,8 +18,8 @@ dependencies:
   - module: google.golang.org/grpc
     version: v1.81.1
   - module: k8s.io/apimachinery
-    version: v0.35.0
+    version: v0.36.1
   - module: k8s.io/client-go
-    version: v0.35.0
+    version: v0.36.1
   - module: sigs.k8s.io/controller-runtime
-    version: v0.23.1
+    version: v0.24.1

--- a/renovate.json
+++ b/renovate.json
@@ -164,7 +164,7 @@
       "minimumReleaseAge": "10 days"
     },
     {
-      "description": "Generated-provider framework deps (pkg/versions/dependencies.yaml) - bump together so crossplane-runtime, controller-runtime, and k8s.io/* stay mutually compatible (individual bumps break the e2e)",
+      "description": "Generated-provider framework deps (pkg/versions/dependencies.yaml) - bump together so crossplane-runtime, controller-runtime, and k8s.io/* stay mutually compatible (individual bumps break the e2e). crossplane-runtime is additionally capped below v2.3.0 by the rule that follows.",
       "matchFileNames": ["pkg/versions/dependencies.yaml"],
       "groupName": "provider framework dependencies",
       "addLabels": ["dependencies", "provider-framework"],
@@ -172,6 +172,12 @@
       "semanticCommitScope": "provider",
       "prPriority": 14,
       "minimumReleaseAge": "7 days"
+    },
+    {
+      "description": "Hold generated providers' crossplane-runtime at v2.2.x. v2.3.0 relocated the common APIs (apis/common/v1, apis/common/v2) into the separate github.com/crossplane/crossplane/apis/v2/core module, but crossplane-tools/angryjet does not yet emit methodsets for the relocated types, so a v2.3.x bump breaks codegen for every scaffolded provider (verified via make e2e-test; the official crossplane/provider-template is likewise still on the v2.x common APIs). Lift this cap once angryjet supports core/v2.",
+      "matchFileNames": ["pkg/versions/dependencies.yaml"],
+      "matchPackageNames": ["github.com/crossplane/crossplane-runtime/v2"],
+      "allowedVersions": "<2.3.0"
     }
   ],
   "customManagers": [


### PR DESCRIPTION
Supersedes #79 (the grouped framework-deps bump), which fails E2E.

## What

Takes only the **k8s.io `v0.35.0` → `v0.36.1`** and **controller-runtime `v0.23.1` → `v0.24.1`** bumps from #79. **crossplane-runtime stays at `v2.2.2`.** Also caps crossplane-runtime `<2.3.0` in `renovate.json` so the grouped framework-deps PR stops re-proposing the broken bump.

## Why crossplane-runtime is held back

crossplane-runtime **v2.3.0** relocated the common APIs (`apis/common/v1`, `apis/common/v2`) into the separate module `github.com/crossplane/crossplane/apis/v2/core/v2` (and renamed `ResourceStatus` → `ManagedResourceStatus`).

`crossplane-tools`/`angryjet` (latest = 2025-10-17) detects managed resources by their embedded `crossplane-runtime/.../apis/common` types and hardcodes those imports in `zz_generated.managed.go`. After the move it emits **zero methodsets**, so every scaffolded provider fails `go build` with `does not implement resource.Managed`. The official [`crossplane/provider-template`](https://github.com/crossplane/provider-template) is likewise still on crossplane-runtime v2.x common APIs.

This was the root cause of #79's E2E failure (`go mod tidy` could not resolve `apis/common/v1` / `apis/common/v2`).

## Verification

- `make e2e-test` — PASSES (full scaffold → angryjet codegen → build, two APIs, update/--adopt).
- `make fmt vet lint test` — PASSES. (gosec G204 is the pre-existing accepted baseline; this change touches only YAML/JSON.)
- Confirmed via the official GitHub release/repo APIs that crossplane-tools has no `core/v2` support yet.

## Follow-up

Lift the Renovate cap and re-attempt the full v2.3.x migration once `angryjet` supports `core/v2`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)