### PR TITLE
feat(templates): migrate generated providers to crossplane-runtime v2.3

### DIFF
--- a/pkg/templates/files/apis/GROUP/VERSION/KIND_types.go.tmpl
+++ b/pkg/templates/files/apis/GROUP/VERSION/KIND_types.go.tmpl
@@ -8,8 +8,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
-	xpv1 "github.com/crossplane/crossplane-runtime/v2/apis/common/v1"
-	xpv2 "github.com/crossplane/crossplane-runtime/v2/apis/common/v2"
+	xpv2 "github.com/crossplane/crossplane/apis/v2/core/v2"
 )
 
 // {{ .Resource.Kind }}Parameters are the configurable fields of a {{ .Resource.Kind }}.
@@ -37,8 +36,8 @@ type {{ .Resource.Kind }}Spec struct {
 // A {{ .Resource.Kind }}Status represents the observed state of a {{ .Resource.Kind }}.
 // +kubebuilder:object:generate=true
 type {{ .Resource.Kind }}Status struct {
-	xpv1.ResourceStatus `json:",inline"`
-	AtProvider          {{ .Resource.Kind }}Observation `json:"atProvider,omitempty"`
+	xpv2.ManagedResourceStatus `json:",inline"`
+	AtProvider                 {{ .Resource.Kind }}Observation `json:"atProvider,omitempty"`
 }
 
 // +kubebuilder:object:root=true

--- a/pkg/templates/files/apis/v1alpha1/types.go.tmpl
+++ b/pkg/templates/files/apis/v1alpha1/types.go.tmpl
@@ -3,15 +3,14 @@
 package v1alpha1
 
 import (
-	xpv1 "github.com/crossplane/crossplane-runtime/v2/apis/common/v1"
-	xpv2 "github.com/crossplane/crossplane-runtime/v2/apis/common/v2"
+	xpv2 "github.com/crossplane/crossplane/apis/v2/core/v2"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // A ProviderConfigStatus defines the status of a Provider.
 // +kubebuilder:object:generate=true
 type ProviderConfigStatus struct {
-	xpv1.ProviderConfigStatus `json:",inline"`
+	xpv2.ProviderConfigStatus `json:",inline"`
 }
 
 // ProviderCredentials required to authenticate.
@@ -19,9 +18,9 @@ type ProviderConfigStatus struct {
 type ProviderCredentials struct {
 	// Source of the provider credentials.
 	// +kubebuilder:validation:Enum=None;Secret;InjectedIdentity;Environment;Filesystem
-	Source xpv1.CredentialsSource `json:"source"`
+	Source xpv2.CredentialsSource `json:"source"`
 
-	xpv1.CommonCredentialSelectors `json:",inline"`
+	xpv2.CommonCredentialSelectors `json:",inline"`
 }
 
 // +kubebuilder:object:generate=true

--- a/pkg/templates/files/internal/controller/KIND/controller.go.tmpl
+++ b/pkg/templates/files/internal/controller/KIND/controller.go.tmpl
@@ -6,11 +6,11 @@ import (
 	"context"
 	"fmt"
 
-	xpv1 "github.com/crossplane/crossplane-runtime/v2/apis/common/v1"
+	"github.com/crossplane/crossplane-runtime/v2/pkg/errors"
 	"github.com/crossplane/crossplane-runtime/v2/pkg/meta"
 	"github.com/crossplane/crossplane-runtime/v2/pkg/reconciler/managed"
 	"github.com/crossplane/crossplane-runtime/v2/pkg/resource"
-	"github.com/pkg/errors"
+	xpv2 "github.com/crossplane/crossplane/apis/v2/core/v2"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -128,7 +128,7 @@ func (c *external) Observe(ctx context.Context, mg resource.Managed) (managed.Ex
 	}
 
 	// Now the resource is in sync and ready to use, so mark it as available.
-	cr.Status.SetConditions(xpv1.Available())
+	cr.Status.SetConditions(xpv2.Available())
 	return managed.ExternalObservation{
 		// Return false when the external resource does not exist. This lets
 		// the managed resource reconciler know that it needs to call Create to
@@ -148,7 +148,7 @@ func (c *external) Observe(ctx context.Context, mg resource.Managed) (managed.Ex
 
 func (c *external) Create(ctx context.Context, mg resource.Managed) (managed.ExternalCreation, error) {
 	cr, ok := mg.(*{{ .Resource.Version }}.{{ .Resource.Kind }})
-	cr.Status.SetConditions(xpv1.Creating())
+	cr.Status.SetConditions(xpv2.Creating())
 	if !ok {
 		return managed.ExternalCreation{}, errors.New(errNot{{ .Resource.Kind }})
 	}
@@ -181,7 +181,7 @@ func (c *external) Update(ctx context.Context, mg resource.Managed) (managed.Ext
 
 func (c *external) Delete(ctx context.Context, mg resource.Managed) (managed.ExternalDelete, error) {
 	cr, ok := mg.(*{{ .Resource.Version }}.{{ .Resource.Kind }})
-	cr.Status.SetConditions(xpv1.Deleting())
+	cr.Status.SetConditions(xpv2.Deleting())
 	if !ok {
 		return managed.ExternalDelete{}, errors.New(errNot{{ .Resource.Kind }})
 	}

--- a/pkg/templates/files/internal/controller/KIND/setup.go.tmpl
+++ b/pkg/templates/files/internal/controller/KIND/setup.go.tmpl
@@ -6,13 +6,13 @@ package {{ .Resource.Kind | lower }}
 
 import (
 	"github.com/crossplane/crossplane-runtime/v2/pkg/controller"
+	"github.com/crossplane/crossplane-runtime/v2/pkg/errors"
 	"github.com/crossplane/crossplane-runtime/v2/pkg/event"
 	"github.com/crossplane/crossplane-runtime/v2/pkg/feature"
 	"github.com/crossplane/crossplane-runtime/v2/pkg/ratelimiter"
 	"github.com/crossplane/crossplane-runtime/v2/pkg/reconciler/managed"
 	"github.com/crossplane/crossplane-runtime/v2/pkg/resource"
 	"github.com/crossplane/crossplane-runtime/v2/pkg/statemetrics"
-	"github.com/pkg/errors"
 	ctrl "sigs.k8s.io/controller-runtime"
 
 	"{{ .Repo }}/apis/{{ .Resource.Group }}/{{ .Resource.Version }}"

--- a/pkg/versions/dependencies.yaml
+++ b/pkg/versions/dependencies.yaml
@@ -10,11 +10,11 @@ dependencies:
   - module: github.com/alecthomas/kingpin/v2
     version: v2.4.0
   - module: github.com/crossplane/crossplane-runtime/v2
-    version: v2.2.2
+    version: v2.3.3
+  - module: github.com/crossplane/crossplane/apis/v2
+    version: v2.3.3
   - module: github.com/google/go-cmp
     version: v0.7.0
-  - module: github.com/pkg/errors
-    version: v0.9.1
   - module: google.golang.org/grpc
     version: v1.81.1
   - module: k8s.io/apimachinery

--- a/renovate.json
+++ b/renovate.json
@@ -164,7 +164,7 @@
       "minimumReleaseAge": "10 days"
     },
     {
-      "description": "Generated-provider framework deps (pkg/versions/dependencies.yaml) - bump together so crossplane-runtime, controller-runtime, and k8s.io/* stay mutually compatible (individual bumps break the e2e). crossplane-runtime is additionally capped below v2.3.0 by the rule that follows.",
+      "description": "Generated-provider framework deps (pkg/versions/dependencies.yaml) - bump together so crossplane-runtime, crossplane/apis, controller-runtime, and k8s.io/* stay mutually compatible (individual bumps break the e2e)",
       "matchFileNames": ["pkg/versions/dependencies.yaml"],
       "groupName": "provider framework dependencies",
       "addLabels": ["dependencies", "provider-framework"],
@@ -172,12 +172,6 @@
       "semanticCommitScope": "provider",
       "prPriority": 14,
       "minimumReleaseAge": "7 days"
-    },
-    {
-      "description": "Hold generated providers' crossplane-runtime at v2.2.x. v2.3.0 relocated the common APIs (apis/common/v1, apis/common/v2) into the separate github.com/crossplane/crossplane/apis/v2/core module, but crossplane-tools/angryjet does not yet emit methodsets for the relocated types, so a v2.3.x bump breaks codegen for every scaffolded provider (verified via make e2e-test; the official crossplane/provider-template is likewise still on the v2.x common APIs). Lift this cap once angryjet supports core/v2.",
-      "matchFileNames": ["pkg/versions/dependencies.yaml"],
-      "matchPackageNames": ["github.com/crossplane/crossplane-runtime/v2"],
-      "allowedVersions": "<2.3.0"
     }
   ],
   "customManagers": [


### PR DESCRIPTION
Follows upstream [`crossplane/provider-template`](https://github.com/crossplane/provider-template) (`42663d1`) onto crossplane-runtime v2.3.

## The v2.3 API move

crossplane-runtime v2.3.0 relocated the common APIs out of `apis/common/v1` + `apis/common/v2` into the **separate `github.com/crossplane/crossplane/apis/v2` module**, under `core/v2`.

| Before | After |
|---|---|
| `xpv1 ".../crossplane-runtime/v2/apis/common/v1"` + `xpv2 ".../apis/common/v2"` | single `xpv2 "github.com/crossplane/crossplane/apis/v2/core/v2"` |
| `xpv1.ResourceStatus` | `xpv2.ManagedResourceStatus` (renamed) |
| `xpv1.Available()` / `Creating()` / `Deleting()` | `xpv2.…` |
| `github.com/pkg/errors` | `crossplane-runtime/v2/pkg/errors` |

Dependencies: crossplane-runtime `v2.2.2` → **`v2.3.3`**, added **`github.com/crossplane/crossplane/apis/v2 v2.3.3`**, dropped `github.com/pkg/errors`. Also removes the Renovate cap that held crossplane-runtime below v2.3.0 — the toolchain now supports the move.

## Codegen note

`angryjet` only emits methodsets for the relocated types from the **2026-07-15 or newer** crossplane-tools build. `go mod tidy` resolves a newer one (`20260719180100`), and codegen correctly produces `zz_generated.managed.go` importing `core/v2`.

## Deliberate deviation from upstream

Upstream added compile-time interface assertions (`_ resource.ModernManaged = &Kind{}`) to its API type files. **These are not scaffolded here.** They reference methods angryjet itself generates, so on a *fresh* scaffold — which has no `zz_generated` files yet — the package cannot type-check and angryjet fails to load it. Upstream only avoids this because its generated files are already committed. The generated provider still implements the interfaces; the assertions were documentation only.

## Verification

- `make e2e-test` — PASSES (scaffold → codegen → build, two APIs, CRD/example generation, update/`--adopt`).
- `make fmt vet lint test` — PASSES.
- **kind cluster (k8s v1.36.1)** — all 6 CRDs install; the built provider starts every controller; sample managed resources reach **`READY=True SYNCED=True`** (`Ready/Available`, `Synced/ReconcileSuccess`) via **both** the `ProviderConfig` and `ClusterProviderConfig` paths; `ProviderConfigUsage` tracked for both; clean deletion with the provider staying healthy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)