### PR TITLE
docs: state the namespaced credential model where authors read it

### DIFF
--- a/docs/provider-guide.md
+++ b/docs/provider-guide.md
@@ -112,12 +112,17 @@ Run `make generate`, and it is available as `cfg.Spec.Endpoint` in `NewClient`.
 Nothing between the two needs changing — the connector passes the whole spec
 through.
 
-### Credentials you resolve yourself
+### Where credentials come from
 
-For pod identity, IRSA or workload identity, set the ProviderConfig's credentials
-source to `None`. `cfg.Credentials` is then empty, and you build the client from
-ambient identity. `cfg.Kube` is available for any lookup the generator did not do
-for you.
+A ProviderConfig is namespaced, and so are its credentials: `secretRef` names a
+Secret in **the ProviderConfig's own namespace** (it has no `namespace` field).
+That is deliberate — it keeps one tenant's config from reaching another's
+Secrets. The available sources are `Secret`, `None` and `InjectedIdentity`.
+
+For pod identity, IRSA or workload identity, set the credentials source to
+`None`. `cfg.Credentials` is then empty, and you build the client from ambient
+identity. `cfg.Kube` is available for any lookup the generator did not do for
+you.
 
 ### CLI flags
 


### PR DESCRIPTION
Follow-up to #127. The same-namespace constraint on `secretRef` was only stated in the upgrade note at the bottom of the provider guide. Someone writing a provider today reads §2's credentials section, so it now says there:

- a ProviderConfig's `secretRef` names a Secret in **its own namespace** (there is no `namespace` field), and why — one tenant's config must not reach another's Secrets;
- the available sources are `Secret`, `None`, `InjectedIdentity`.

Docs-only. Verified: every link and anchor across README, CLAUDE.md, WORKFLOWS.md and `docs/` resolves.